### PR TITLE
(NO-TICKET) - version bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "php": "^7.3|^8.0",
         "ext-ctype": "*",
         "theseer/fdomdocument": "^1.6",
-        "symfony/finder": "^6.2.3"
+        "symfony/finder": "^7.0"
     },
     "config": {
         "platform": {
-            "php": "8.1"
+            "php": "8.2"
         },
         "optimize-autoloader": true,
         "sort-packages": true


### PR DESCRIPTION
### Update minimum PHP version from 8.1 to 8.2 and upgrade symfony/finder dependency from ^6.2.3 to ^7.0 in composer.json
Updates dependency requirements in [composer.json](https://github.com/parkhub/finder-facade/pull/2/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34):
- Increases minimum PHP version requirement from 8.1 to 8.2
- Upgrades `symfony/finder` package requirement from ^6.2.3 to ^7.0

#### 📍Where to Start
Start with the dependency changes in [composer.json](https://github.com/parkhub/finder-facade/pull/2/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34).

----

_[Macroscope](https://app.macroscope.com) summarized 5a78b98._